### PR TITLE
Deployer types

### DIFF
--- a/any.go
+++ b/any.go
@@ -20,6 +20,10 @@ func (a anyDeployerFactory[T]) ID() string {
 	return a.factory.ID()
 }
 
+func (a anyDeployerFactory[T]) DeploymentType() DeploymentType {
+	return a.factory.DeploymentType()
+}
+
 func (a anyDeployerFactory[T]) ConfigurationSchema() schema.Object {
 	return a.factory.ConfigurationSchema()
 }

--- a/any.go
+++ b/any.go
@@ -16,8 +16,8 @@ type anyDeployerFactory[T any] struct {
 	factory ConnectorFactory[T]
 }
 
-func (a anyDeployerFactory[T]) ID() string {
-	return a.factory.ID()
+func (a anyDeployerFactory[T]) Name() string {
+	return a.factory.Name()
 }
 
 func (a anyDeployerFactory[T]) DeploymentType() DeploymentType {

--- a/interface.go
+++ b/interface.go
@@ -9,12 +9,15 @@ import (
 	"go.flow.arcalot.io/pluginsdk/schema"
 )
 
+type DeploymentType string
+
 // ConnectorFactory is an abstraction that hides away the complexity of instantiating a Connector. Its main purpose is
 // to provide the configuration schema for the connector and then create an instance of said connector.
 type ConnectorFactory[ConfigType any] interface {
 	ID() string
 	ConfigurationSchema() *schema.TypedScopeSchema[ConfigType]
 	Create(config ConfigType, logger log.Logger) (Connector, error)
+	DeploymentType() DeploymentType
 }
 
 // AnyConnectorFactory is the untyped version of ConnectorFactory.
@@ -22,6 +25,7 @@ type AnyConnectorFactory interface {
 	ID() string
 	ConfigurationSchema() schema.Object
 	Create(config any, logger log.Logger) (Connector, error)
+	DeploymentType() DeploymentType
 }
 
 // Connector is responsible for deploying a container image on the specified target. Once deployed and ready, the

--- a/interface.go
+++ b/interface.go
@@ -14,7 +14,7 @@ type DeploymentType string
 // ConnectorFactory is an abstraction that hides away the complexity of instantiating a Connector. Its main purpose is
 // to provide the configuration schema for the connector and then create an instance of said connector.
 type ConnectorFactory[ConfigType any] interface {
-	ID() string
+	Name() string
 	ConfigurationSchema() *schema.TypedScopeSchema[ConfigType]
 	Create(config ConfigType, logger log.Logger) (Connector, error)
 	DeploymentType() DeploymentType
@@ -22,7 +22,7 @@ type ConnectorFactory[ConfigType any] interface {
 
 // AnyConnectorFactory is the untyped version of ConnectorFactory.
 type AnyConnectorFactory interface {
-	ID() string
+	Name() string
 	ConfigurationSchema() schema.Object
 	Create(config any, logger log.Logger) (Connector, error)
 	DeploymentType() DeploymentType

--- a/registry/helper_test.go
+++ b/registry/helper_test.go
@@ -19,6 +19,10 @@ func (t testNewFactory) ID() string {
 	return "test"
 }
 
+func (t testNewFactory) DeploymentType() deployer.DeploymentType {
+	return t.DeploymentType()
+}
+
 func (t testNewFactory) ConfigurationSchema() schema.Object {
 	return schema.NewTypedScopeSchema[testConfig](
 		schema.NewStructMappedObjectSchema[testConfig](
@@ -37,4 +41,8 @@ type testConnector struct {
 
 func (t testConnector) Deploy(_ context.Context, _ string) (deployer.Plugin, error) {
 	return nil, fmt.Errorf("not implemented")
+}
+
+func (t testConnector) DeploymentType() deployer.DeploymentType {
+	return "test"
 }

--- a/registry/helper_test.go
+++ b/registry/helper_test.go
@@ -15,7 +15,7 @@ type testConfig struct {
 type testNewFactory struct {
 }
 
-func (t testNewFactory) ID() string {
+func (t testNewFactory) Name() string {
 	return "test"
 }
 

--- a/registry/helper_test.go
+++ b/registry/helper_test.go
@@ -12,15 +12,23 @@ import (
 type testConfig struct {
 }
 
+var testConfigInput = map[string]any{
+	"test-type": map[string]any{
+		"deployer_name": "test",
+	},
+}
+
 type testNewFactory struct {
 }
+
+var testDeploymentType = deployer.DeploymentType("test-type")
 
 func (t testNewFactory) Name() string {
 	return "test"
 }
 
 func (t testNewFactory) DeploymentType() deployer.DeploymentType {
-	return t.DeploymentType()
+	return "test-type"
 }
 
 func (t testNewFactory) ConfigurationSchema() schema.Object {
@@ -43,6 +51,6 @@ func (t testConnector) Deploy(_ context.Context, _ string) (deployer.Plugin, err
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (t testConnector) DeploymentType() deployer.DeploymentType {
-	return "test"
-}
+//func (t testConnector) DeploymentType() deployer.DeploymentType {
+//	return "test-type"
+//}

--- a/registry/helper_test.go
+++ b/registry/helper_test.go
@@ -50,7 +50,3 @@ type testConnector struct {
 func (t testConnector) Deploy(_ context.Context, _ string) (deployer.Plugin, error) {
 	return nil, fmt.Errorf("not implemented")
 }
-
-//func (t testConnector) DeploymentType() deployer.DeploymentType {
-//	return "test-type"
-//}

--- a/registry/new.go
+++ b/registry/new.go
@@ -8,13 +8,21 @@ import (
 
 // New creates a new registry with the given factories.
 func New(factory ...deployer.AnyConnectorFactory) Registry {
-	factories := make(map[string]deployer.AnyConnectorFactory, len(factory))
+	factories := make(map[deployer.DeploymentType]map[string]deployer.AnyConnectorFactory, len(factory))
 
 	for _, f := range factory {
-		if v, ok := factories[f.ID()]; ok {
-			panic(fmt.Errorf("duplicate deployer factory ID: %s (first: %T, second: %T)", f.ID(), v, f))
+		deploymentType := f.DeploymentType()
+		category, categoryCreated := factories[deploymentType]
+		if !categoryCreated {
+			category = make(map[string]deployer.AnyConnectorFactory)
+			factories[deploymentType] = category
 		}
-		factories[f.ID()] = f
+
+		if v, ok := category[f.ID()]; ok {
+			panic(fmt.Errorf("duplicate deployer factory ID for deployment type %s: %s (first: %T, second: %T)",
+				deploymentType, f.ID(), v, f))
+		}
+		category[f.ID()] = f
 	}
 
 	return &registry{

--- a/registry/new.go
+++ b/registry/new.go
@@ -18,11 +18,11 @@ func New(factory ...deployer.AnyConnectorFactory) Registry {
 			factories[deploymentType] = category
 		}
 
-		if v, ok := category[f.ID()]; ok {
-			panic(fmt.Errorf("duplicate deployer factory ID for deployment type %s: %s (first: %T, second: %T)",
-				deploymentType, f.ID(), v, f))
+		if v, ok := category[f.Name()]; ok {
+			panic(fmt.Errorf("duplicate deployer factory Name for deployment type %s: %s (first: %T, second: %T)",
+				deploymentType, f.Name(), v, f))
 		}
-		category[f.ID()] = f
+		category[f.Name()] = f
 	}
 
 	return &registry{

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -47,6 +47,16 @@ func (r registry) List() map[string]schema.Object {
 	return result
 }
 
+func (r registry) Slice() []deployer.AnyConnectorFactory {
+	slc := make([]deployer.AnyConnectorFactory, 0)
+	for _, factories := range r.deployerFactories {
+		for _, factory := range factories {
+			slc = append(slc, factory)
+		}
+	}
+	return slc
+}
+
 func (r registry) DeployConfigSchema(deploymentType deployer.DeploymentType) schema.OneOf[string] {
 	schemas := make(map[string]schema.Object, len(r.deployerFactories))
 	for id, factory := range r.deployerFactories[deploymentType] {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -39,7 +39,7 @@ func (r registry) Schema() schema.OneOf[string] {
 	}
 	return schema.NewOneOfStringSchema[any](
 		schemas,
-		"type",
+		"deployer_id",
 	)
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -13,28 +13,43 @@ import (
 type Registry interface {
 	// List lists the registered deployers with their scopes.
 	List() map[string]schema.Object
-	// Schema returns a composite schema for the registry.
-	Schema() schema.OneOf[string]
+	// DeploymentTypes returns a slice of all deployment types in the registry.
+	DeploymentTypes() []deployer.DeploymentType
+	// DeployConfigSchema returns a composite schema for all types in the registry of that deployment type.
+	DeployConfigSchema(deploymentType deployer.DeploymentType) schema.OneOf[string]
 	// Create creates a connector with the given configuration type. The registry must identify the correct deployer
 	// based on the type passed.
-	Create(config any, logger log.Logger) (deployer.Connector, error)
+	Create(deploymentType deployer.DeploymentType, config any, logger log.Logger) (deployer.Connector, error)
 }
 
 type registry struct {
-	deployerFactories map[string]deployer.AnyConnectorFactory
+	deployerFactories map[deployer.DeploymentType]map[string]deployer.AnyConnectorFactory
+}
+
+func (r registry) DeploymentTypes() []deployer.DeploymentType {
+	typeList := make([]deployer.DeploymentType, len(r.deployerFactories))
+
+	i := 0
+	for k := range r.deployerFactories {
+		typeList[i] = k
+		i++
+	}
+	return typeList
 }
 
 func (r registry) List() map[string]schema.Object {
 	result := make(map[string]schema.Object, len(r.deployerFactories))
-	for id, factory := range r.deployerFactories {
-		result[id] = factory.ConfigurationSchema()
+	for _, factories := range r.deployerFactories {
+		for id, factory := range factories {
+			result[id] = factory.ConfigurationSchema()
+		}
 	}
 	return result
 }
 
-func (r registry) Schema() schema.OneOf[string] {
+func (r registry) DeployConfigSchema(deploymentType deployer.DeploymentType) schema.OneOf[string] {
 	schemas := make(map[string]schema.Object, len(r.deployerFactories))
-	for id, factory := range r.deployerFactories {
+	for id, factory := range r.deployerFactories[deploymentType] {
 		schemas[id] = factory.ConfigurationSchema()
 	}
 	return schema.NewOneOfStringSchema[any](
@@ -43,12 +58,12 @@ func (r registry) Schema() schema.OneOf[string] {
 	)
 }
 
-func (r registry) Create(config any, logger log.Logger) (deployer.Connector, error) {
+func (r registry) Create(deploymentType deployer.DeploymentType, config any, logger log.Logger) (deployer.Connector, error) {
 	if config == nil {
 		return nil, fmt.Errorf("the deployer configuration cannot be nil")
 	}
 	reflectedConfig := reflect.ValueOf(config)
-	for _, factory := range r.deployerFactories {
+	for _, factory := range r.deployerFactories[deploymentType] {
 		if factory.ConfigurationSchema().ReflectedType() == reflectedConfig.Type() {
 			return factory.Create(config, logger)
 		}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -64,7 +64,7 @@ func (r registry) DeployConfigSchema(deploymentType deployer.DeploymentType) sch
 	}
 	return schema.NewOneOfStringSchema[any](
 		schemas,
-		"deployer_id",
+		"deployer_name",
 	)
 }
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -21,7 +21,7 @@ func testRegistrySchemaIncorrectInput(t *testing.T) {
 	)
 	schema := r.Schema()
 
-	if _, err := schema.Unserialize(map[string]any{"type": "non-existent"}); err == nil {
+	if _, err := schema.Unserialize(map[string]any{"deployer_id": "non-existent"}); err == nil {
 		t.Fatalf("No error returned")
 	}
 
@@ -36,7 +36,7 @@ func testRegistrySchemaCorrectInput(t *testing.T) {
 	)
 	schema := r.Schema()
 
-	unserializedData, err := schema.Unserialize(map[string]any{"type": "test"})
+	unserializedData, err := schema.Unserialize(map[string]any{"deployer_id": "test"})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,7 +1,6 @@
 package registry_test
 
 import (
-	"go.flow.arcalot.io/deployer"
 	"testing"
 
 	"go.arcalot.io/assert"
@@ -20,9 +19,11 @@ func testRegistrySchemaIncorrectInput(t *testing.T) {
 	r := registry.New(
 		&testNewFactory{},
 	)
-	schema := r.Schema()
+	schema := r.DeployConfigSchema("test-type")
 
-	if _, err := schema.Unserialize(map[string]any{"deployer_id": "non-existent"}); err == nil {
+	if _, err := schema.Unserialize(map[string]any{
+		"deployer_name": "non-existent",
+	}); err == nil {
 		t.Fatalf("No error returned")
 	}
 
@@ -35,9 +36,11 @@ func testRegistrySchemaCorrectInput(t *testing.T) {
 	r := registry.New(
 		&testNewFactory{},
 	)
-	schema := r.Schema()
+	schema := r.DeployConfigSchema("test-type")
 
-	unserializedData, err := schema.Unserialize(map[string]any{"deployer_id": "test"})
+	unserializedData, err := schema.Unserialize(map[string]any{
+		"deployer_name": "test",
+	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -58,7 +61,8 @@ func testRegistryCreateCorrectCreation(t *testing.T) {
 	r := registry.New(
 		&testNewFactory{},
 	)
-	connector, err := r.Create(testConfig{}, log.NewTestLogger(t))
+
+	connector, err := r.Create(testDeploymentType, testConfig{}, log.NewTestLogger(t))
 	assert.NoError(t, err)
 	if _, ok := connector.(*testConnector); !ok {
 		t.Fatalf("Incorrect connector returned: %T", connector)
@@ -67,13 +71,11 @@ func testRegistryCreateCorrectCreation(t *testing.T) {
 
 func testRegistryCreateIncorrectConfigType(t *testing.T) {
 	t.Parallel()
-	type testStruct struct {
-	}
 
 	r := registry.New(
 		&testNewFactory{},
 	)
-	_, err := r.Create(testStruct{}, log.NewTestLogger(t))
+	_, err := r.Create(testDeploymentType, map[string]any{}, log.NewTestLogger(t))
 	if err == nil {
 		t.Fatalf("expected error, no error returned")
 	}
@@ -84,7 +86,7 @@ func testRegistryCreateNilConfig(t *testing.T) {
 	r := registry.New(
 		&testNewFactory{},
 	)
-	_, err := r.Create(deployer.DeploymentType("builtin"), testStruct{}, log.NewTestLogger(t))
+	_, err := r.Create(testDeploymentType, nil, log.NewTestLogger(t))
 	if err == nil {
 		t.Fatalf("expected error, no error returned")
 	}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,6 +1,7 @@
 package registry_test
 
 import (
+	"go.flow.arcalot.io/deployer"
 	"testing"
 
 	"go.arcalot.io/assert"
@@ -83,7 +84,7 @@ func testRegistryCreateNilConfig(t *testing.T) {
 	r := registry.New(
 		&testNewFactory{},
 	)
-	_, err := r.Create(nil, log.NewTestLogger(t))
+	_, err := r.Create(deployer.DeploymentType("builtin"), testStruct{}, log.NewTestLogger(t))
 	if err == nil {
 		t.Fatalf("expected error, no error returned")
 	}


### PR DESCRIPTION
## Changes introduced with this PR

- [X] Add deployment type function to deployer connector interface.
- [X] Add function to get all deployment types in an aggregate of deployer factories.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).